### PR TITLE
Fixed typo in en_us version of loading screen tips

### DIFF
--- a/.minecraft/openloader/resources/2cs/assets/2cs/lang/en_us.json
+++ b/.minecraft/openloader/resources/2cs/assets/2cs/lang/en_us.json
@@ -27,7 +27,7 @@
     "2cs.tip.jei": "Search JEI maybe help.",
     "2cs.tip.clay": "It's useful to collect clay in the early age.",
     "2cs.tip.ae2": "Use Applied Energistics 2 mod to make automation can improve your efficiency.",
-    "2cs.tip.trashcan": "The Ultimate Trashcan can destory every kind of trash, even the Exhausted Nuclear Waste in Mekanism.",
+    "2cs.tip.trashcan": "The Ultimate Trashcan can destroy every kind of trash, even the Exhausted Nuclear Waste in Mekanism.",
     "2cs.tip.kelp": "Kelp can also be grown in Botany pots.",
     "2cs.tip.jei_hide": "There are some useless things are hidden in JEI.",
     "2cs.tip.ae&drawer": "Drawer controller can be connected to AE network by connecting ME storage bus.",


### PR DESCRIPTION
I have no idea how that newline at the end of the file got there but i wasn't able to get rid of it